### PR TITLE
retorna instâncias de processos baseadas nas entidades

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,10 +159,28 @@ server.post('/:collection', (req, res, next) => {
         });
 });
 
+server.get('/instances/byEntities', (req, res, next) => {
+    var query = clone(req.query);
+    var systemId = query["systemId"]
+    var collection_name = ("query_instance_"+systemId).replace("-","_");
+    delete query["app_origin"]
+    var entities = query["entities"].split(",")
+
+    sto.findDocument(collection_name, {"entities": { $elemMatch: {"name" : { $in:entities } } } }).
+        then((result) => {
+            res.send(result);
+        }).
+        catch((err) => {
+            console.log("Erro no 'first':", err);
+            res.send(500, err.toString());
+        });
+});
+
 server.get('/:collection', (req, res, next) => {
     var collection_name = req.params.collection;
     var query = clone(req.query);
     delete query["app_origin"]
+
     sto.findDocument(collection_name, query || {}).
         then((result) => {
             res.send(result);
@@ -172,6 +190,8 @@ server.get('/:collection', (req, res, next) => {
             res.send(500, err.toString());
         });
 });
+
+
 
 server.put('/:collection', (req, res, next) => {
     var collection_name = req.params.collection;


### PR DESCRIPTION
Essa feature, retorna as instâncias de processos que sensibilizaram determinada entidades com todos os ids que foram consultados durante a etapa de busca do SDK
Segue um exemplo em python para realizar a consulta:

```python
import requests

url = "http://localhost:9091/instances/byEntities"

querystring = {"systemId":"ec498841-59e5-47fd-8075-136d79155705","entities":"conta,operacao"}
response = requests.request("GET", url, params=querystring)

print(response.text)
```