### PR TITLE
adicionar suporte gridfs

### DIFF
--- a/bufferStream.js
+++ b/bufferStream.js
@@ -1,0 +1,22 @@
+var stream = require('stream');
+var util = require('util');
+
+function BufferStream () { // step 2
+    this.buffer = []
+    stream.Writable.call(this);
+};
+util.inherits(BufferStream, stream.Writable); // step 1
+
+BufferStream.prototype._write = function (chunk, encoding, done) { // step 3
+    this.buffer.push(chunk.toString());
+    done();
+}
+BufferStream.prototype.toJSON = function(){
+    return JSON.parse(this.buffer.join(""))
+}
+
+BufferStream.prototype.toString = function(){
+    return this.buffer.join("")
+}
+
+module.exports = BufferStream

--- a/gridfs.js
+++ b/gridfs.js
@@ -1,0 +1,47 @@
+var mongo = require('mongodb');
+const BufferStream = require('./bufferStream');
+
+
+module.exports = function(){
+    var self = this;
+
+    self.setClient = (client) => {
+        self.client = client;
+    };
+
+    self.defineBucket = (database, name, chunkSize) => {
+        self.bucketName = name;
+        self.database = database;
+        self.chunkSize = chunkSize;
+    };
+
+    self.upload = (fileName,file) => {
+        return new Promise((resolve,reject)=>{
+            var bucket = new mongo.GridFSBucket(self.client.db(self.database), {
+                chunkSizeBytes: self.chunkSize,
+                bucketName: self.bucketName
+            });
+            var w = bucket.openUploadStream(fileName,{
+                contentType:"application/json"
+            })
+            w.once('finish',resolve)
+            w.on('error',reject)
+            w.write(Buffer.from(JSON.stringify(file)))
+            w.end()
+        });
+    };
+
+    self.download = (fileName) => {
+        return new Promise((resolve,reject)=>{
+            var stream = new BufferStream()
+            var bucket = new mongo.GridFSBucket(self.client.db(self.database), {
+                chunkSizeBytes: self.chunkSize,
+                bucketName: self.bucketName
+            });
+            bucket.openDownloadStreamByName(fileName).pipe(stream).on('finish',()=>{
+                resolve(stream.toJSON())
+            }).on('error',reject);
+        })
+    };
+    return self;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,6 +177,11 @@
         "semver-store": "^0.3.0"
       }
     },
+    "flushwritable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flushwritable/-/flushwritable-1.0.0.tgz",
+      "integrity": "sha1-PjKNj95BKtR+c44751C00pAENJg="
+    },
     "formidable": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
@@ -201,6 +206,22 @@
         "minimatch": "2 || 3",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "gridfs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gridfs/-/gridfs-1.0.0.tgz",
+      "integrity": "sha1-/nXyzoF9AHhQP8YOHLtmWsiOpHc=",
+      "requires": {
+        "gridfs-stream": "^1.1.1"
+      }
+    },
+    "gridfs-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gridfs-stream/-/gridfs-stream-1.1.1.tgz",
+      "integrity": "sha1-PdOhAOwgIaGBKC9utGcJY2B034k=",
+      "requires": {
+        "flushwritable": "^1.0.0"
       }
     },
     "handle-thing": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "gridfs": "^1.0.0",
+    "gridfs-stream": "^1.1.1",
     "mongodb": "^3.0.2",
     "restify": "^7.2.1",
     "sha1": "^1.1.1",


### PR DESCRIPTION
O suporte ao gridfs foi adicionado para possibilitar a escrita de memoria de cálculo com tamanho superior à 16M.